### PR TITLE
test: fix too many input rejected for CLFees

### DIFF
--- a/test/pool-cl/CLFees.t.sol
+++ b/test/pool-cl/CLFees.t.sol
@@ -97,9 +97,10 @@ contract CLFeesTest is Test, Deployers, TokenFixture, GasSnapshot {
     }
 
     function testNoProtocolFee(uint16 protocolSwapFee) public {
-        vm.assume(protocolSwapFee < 2 ** 16);
-        vm.assume(protocolSwapFee >> 8 >= 4);
-        vm.assume(protocolSwapFee % 256 >= 4);
+        // Early return instead of vm.assume (too many input rejected)
+        if (protocolSwapFee >= 2 ** 16) return;
+        if (protocolSwapFee >> 8 < 4) return;
+        if (protocolSwapFee % 256 < 4) return;
 
         protocolFeeController.setSwapFeeForPool(key.toId(), protocolSwapFee);
         manager.setProtocolFeeController(IProtocolFeeController(protocolFeeController));


### PR DESCRIPTION
test failure from past 2 merged PR:
1/ https://github.com/pancakeswap/pancake-v4-core/actions/runs/8596920130/job/23554484311
2/ https://github.com/pancakeswap/pancake-v4-core/actions/runs/8597014954/job/23554775714 

if got suggestion on `bound(..)` -- that would be great 