### PR TITLE
fix: a edge case for testSwap

### DIFF
--- a/test/pool-cl/libraries/CLPool.t.sol
+++ b/test/pool-cl/libraries/CLPool.t.sol
@@ -93,6 +93,8 @@ contract PoolTest is Test {
         CLPool.SwapParams memory swapParams,
         uint24 swapFee
     ) public {
+        swapParams.amountSpecified = int256(bound(swapParams.amountSpecified, 0, type(int128).max));
+
         testModifyPosition(sqrtPriceX96, modifyLiquidityParams, swapFee);
 
         swapParams.tickSpacing = modifyLiquidityParams.tickSpacing;


### PR DESCRIPTION
This should fix https://github.com/pancakeswap/pancake-v4-core/issues/38

Context:

The error happens when:
1. `swapParams.amountSpecified` is greater than `type(int128).max` i.e. `170141183460469231731687303715884105727`
2. Pool has enough liquidity to digest all the amountSpecified
3. In this case, amountSpecified will be exactly either `balanceDelta.amount0` or `balanceDelta.amount1` which is `int128`
4. It results in the call `toInt128()` failed 


![CleanShot 2024-05-13 at 16 06 53@2x](https://github.com/pancakeswap/pancake-v4-core/assets/137024020/be5e1096-316d-455b-b4c7-869c6e4cdef8)
