### PR TITLE
refactor: update solmate remapping

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -2,4 +2,4 @@ ds-test/=lib/forge-std/lib/ds-test/src/
 forge-gas-snapshot/=lib/forge-gas-snapshot/src/
 forge-std/=lib/forge-std/src/
 @openzeppelin/=lib/openzeppelin-contracts/
-solmate/=lib/solmate/src/
+solmate/=lib/solmate/

--- a/src/test/MockFeePoolManager.sol
+++ b/src/test/MockFeePoolManager.sol
@@ -8,7 +8,7 @@ import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {ProtocolFees} from "../ProtocolFees.sol";
 import {LPFeeLibrary} from "../libraries/LPFeeLibrary.sol";
 import {ProtocolFeeLibrary} from "../libraries/ProtocolFeeLibrary.sol";
-import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
+import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
 
 /**
  * @dev A MockFeePoolManager meant to test Fees functionality

--- a/test/ProtocolFees.t.sol
+++ b/test/ProtocolFees.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
-import "solmate/test/utils/mocks/MockERC20.sol";
+import "solmate/src/test/utils/mocks/MockERC20.sol";
 import "../src/test/MockFeePoolManager.sol";
 import "../src/test/fee/MockFeeManagerHook.sol";
 import {

--- a/test/helpers/SortTokens.sol
+++ b/test/helpers/SortTokens.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {Currency} from "../../src/types/Currency.sol";
 
 library SortTokens {

--- a/test/helpers/TokenFixture.sol
+++ b/test/helpers/TokenFixture.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Currency} from "../../src/types/Currency.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {SortTokens} from "./SortTokens.sol";
 
 contract TokenFixture {

--- a/test/libraries/Currency.t.sol
+++ b/test/libraries/Currency.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";
 import {TokenRejecter} from "../helpers/TokenRejecter.sol";
 import {TokenSender} from "../helpers/TokenSender.sol";

--- a/test/pool-bin/BinHookReturnsDelta.t.sol
+++ b/test/pool-bin/BinHookReturnsDelta.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {IVault} from "../../src/interfaces/IVault.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
 import {IBinPoolManager} from "../../src/pool-bin/interfaces/IBinPoolManager.sol";

--- a/test/pool-bin/BinHookReturnsFee.t.sol
+++ b/test/pool-bin/BinHookReturnsFee.t.sol
@@ -14,7 +14,7 @@ import {BinPoolManager} from "../../src/pool-bin/BinPoolManager.sol";
 import {IBinPoolManager} from "../../src/pool-bin/interfaces/IBinPoolManager.sol";
 import {BinDynamicReturnsFeeHook} from "./helpers/BinDynamicReturnsFeeHook.sol";
 import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {FullMath} from "../../src/pool-cl/libraries/FullMath.sol";
 import {BalanceDelta} from "../../src/types/BalanceDelta.sol";
 import {BinTestHelper} from "./helpers/BinTestHelper.sol";

--- a/test/pool-bin/BinHookRevertWithReason.t.sol
+++ b/test/pool-bin/BinHookRevertWithReason.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {Vault} from "../../src/Vault.sol";
 import {Currency} from "../../src/types/Currency.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";

--- a/test/pool-bin/BinHookSkipCallback.t.sol
+++ b/test/pool-bin/BinHookSkipCallback.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {IVault} from "../../src/interfaces/IVault.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
 import {IBinPoolManager} from "../../src/pool-bin/interfaces/IBinPoolManager.sol";

--- a/test/pool-bin/BinPoolManager.t.sol
+++ b/test/pool-bin/BinPoolManager.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {LPFeeLibrary} from "../../src/libraries/LPFeeLibrary.sol";
 import {IVault} from "../../src/interfaces/IVault.sol";
 import {IProtocolFees} from "../../src/interfaces/IProtocolFees.sol";

--- a/test/pool-bin/BinPoolManagerBehaviorComparison.t.sol
+++ b/test/pool-bin/BinPoolManagerBehaviorComparison.t.sol
@@ -7,7 +7,7 @@ import {Vault} from "../../src/Vault.sol";
 import {IVault} from "../../src/interfaces/IVault.sol";
 import {BinPoolManager} from "../../src/pool-bin/BinPoolManager.sol";
 import {IBinPoolManager} from "../../src/pool-bin/interfaces/IBinPoolManager.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {Currency} from "../../src/types/Currency.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
 import {IHooks} from "../../src/interfaces/IHooks.sol";

--- a/test/pool-bin/libraries/BinPoolFee.t.sol
+++ b/test/pool-bin/libraries/BinPoolFee.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {IProtocolFees} from "../../../src/interfaces/IProtocolFees.sol";
 import {IVault} from "../../../src/interfaces/IVault.sol";
 import {IHooks} from "../../../src/interfaces/IHooks.sol";

--- a/test/pool-cl/CLHookReturnsFee.t.sol
+++ b/test/pool-cl/CLHookReturnsFee.t.sol
@@ -15,7 +15,7 @@ import {Deployers} from "./helpers/Deployers.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import {CLDynamicReturnsFeeHook} from "./helpers/CLDynamicReturnsFeeHook.sol";
 import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {FullMath} from "../../src/pool-cl/libraries/FullMath.sol";
 import {BalanceDelta} from "../../src/types/BalanceDelta.sol";
 import {TokenFixture} from "../helpers/TokenFixture.sol";

--- a/test/pool-cl/CLPoolManager.t.sol
+++ b/test/pool-cl/CLPoolManager.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import {IVault} from "../../src/interfaces/IVault.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {Vault} from "../../src/Vault.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
 import {ICLPoolManager} from "../../src/pool-cl/interfaces/ICLPoolManager.sol";

--- a/test/pool-cl/CLProtocolFees.t.sol
+++ b/test/pool-cl/CLProtocolFees.t.sol
@@ -16,7 +16,7 @@ import {PoolIdLibrary} from "../../src/types/PoolId.sol";
 import {Deployers} from "./helpers/Deployers.sol";
 import {TokenFixture} from "../helpers/TokenFixture.sol";
 import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {MockHooks} from "./helpers/MockHooks.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import {CLPoolManagerRouter} from "./helpers/CLPoolManagerRouter.sol";

--- a/test/pool-cl/helpers/Deployers.sol
+++ b/test/pool-cl/helpers/Deployers.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {Hooks} from "../../../src/libraries/Hooks.sol";
 import {Currency} from "../../../src/types/Currency.sol";
 import {IHooks} from "../../../src/interfaces/IHooks.sol";

--- a/test/pool-cl/libraries/SwapMath.t.sol
+++ b/test/pool-cl/libraries/SwapMath.t.sol
@@ -5,7 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import {SwapMath} from "../../../src/pool-cl/libraries/SwapMath.sol";
 import {FixedPoint96} from "../../../src/pool-cl/libraries/FixedPoint96.sol";
-import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
+import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
 import {SqrtPriceMath} from "../../../src/pool-cl/libraries/SqrtPriceMath.sol";
 
 contract SwapMathTest is Test, GasSnapshot {

--- a/test/vault/Vault.t.sol
+++ b/test/vault/Vault.t.sol
@@ -6,7 +6,7 @@ import "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import {Vault} from "../../src/Vault.sol";
 import {BalanceDelta, toBalanceDelta} from "../../src/types/BalanceDelta.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
 import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";

--- a/test/vault/VaultInvariant.t.sol
+++ b/test/vault/VaultInvariant.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import "forge-std/Test.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {Vault} from "../../src/Vault.sol";
 import {BalanceDelta, toBalanceDelta} from "../../src/types/BalanceDelta.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";

--- a/test/vault/VaultReentrancy.t.sol
+++ b/test/vault/VaultReentrancy.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
 import {ILockCallback} from "../../src/interfaces/ILockCallback.sol";

--- a/test/vault/VaultSync.t.sol
+++ b/test/vault/VaultSync.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
-import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 
 import {IVault, Vault} from "../../src/Vault.sol";
 import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";


### PR DESCRIPTION
This PR updates `solmate` remapping to prevent clashes with permit2

eg. https://github.com/pancakeswap/permit2/blob/main/src/AllowanceTransfer.sol

```
import {SafeTransferLib} from "solmate/src/utils/SafeTransferLib.sol";
```