### PR TITLE
test: fix fuzz test

### DIFF
--- a/test/pool-bin/BinPoolManager.t.sol
+++ b/test/pool-bin/BinPoolManager.t.sol
@@ -936,7 +936,7 @@ contract BinPoolManagerTest is Test, GasSnapshot, BinTestHelper {
     }
 
     function testFuzz_SetMinBinSharesForDonate(uint256 minShare) public {
-        vm.assume(minShare >= 1e18);
+        minShare = bound(minShare, 1e18, type(uint256).max);
 
         vm.expectEmit();
         emit IBinPoolManager.SetMinBinSharesForDonate(minShare);


### PR DESCRIPTION
This PR fix the fuzz test error found at https://github.com/pancakeswap/pancake-v4-core/actions/runs/10556770710/job/29242988635

```
Failing tests:
Encountered 1 failing test in test/pool-bin/BinPoolManager.t.sol:BinPoolManagerTest
[FAIL. Reason: The `vm.assume` cheatcode rejected too many inputs (65536 allowed)] testFuzz_SetMinBinSharesForDonate(uint256) (runs: 59933, μ: 41650, ~: 41655)
```