### PR TITLE
Align dynamic pool default protocol fee with docs

### DIFF
--- a/src/ProtocolFeeController.sol
+++ b/src/ProtocolFeeController.sol
@@ -35,8 +35,8 @@ contract ProtocolFeeController is IProtocolFeeController, Ownable2Step {
 
     /// @notice the default protocol fee for dynamic fee pool,
     /// every newly created dynamic fee pool will have this default protocol fee
-    /// @dev 1000 = 0.1%, the initial setting is 0.03% i.e. 3bps
-    uint24 public defaultProtocolFeeForDynamicFeePool = 300;
+    /// @dev 1000 = 0.1%, the initial setting is 0%
+    uint24 public defaultProtocolFeeForDynamicFeePool = 0;
 
     event DefaultProtocolFeeForDynamicFeePoolUpdated(
         uint24 oldDefaultProtocolFeeForDynamicFeePool, uint24 newDefaultProtocolFeeForDynamicFeePool
@@ -53,7 +53,7 @@ contract ProtocolFeeController is IProtocolFeeController, Ownable2Step {
 
     /// @notice Set the default protocol fee for dynamic fee pool, this will only impact the newly created dynamic fee pool
     /// all those existing dynamic fee pools will not be affected, they will keep using the default protocol fee set at the time of creation
-    /// @param newDefaultProtocolFeeForDynamicFeePool 1000 = 0.1%, the initial setting is 0.03% i.e. 3bps
+    /// @param newDefaultProtocolFeeForDynamicFeePool 1000 = 0.1%, the initial setting is 0%
     function setDefaultProtocolFeeForDynamicFeePool(uint24 newDefaultProtocolFeeForDynamicFeePool) external onlyOwner {
         // cap the protocol fee at 0.4%, if it's over the limit we revert the tx
         if (newDefaultProtocolFeeForDynamicFeePool > ProtocolFeeLibrary.MAX_PROTOCOL_FEE) {

--- a/test/ProtocolFeeController.t.sol
+++ b/test/ProtocolFeeController.t.sol
@@ -37,8 +37,8 @@ contract ProtocolFeeControllerTest is Test, BinTestHelper, TokenFixture {
     /// @notice 100% in hundredths of a bip
     uint256 private constant ONE_HUNDRED_PERCENT_RATIO = 1e6;
 
-    /// @dev the initial setting of the default protocol fee for dynamic fee pool is 0.03% i.e. 3bps
-    uint24 private constant DEFAULT_PROTOCOL_FEE_FOR_DYNAMIC_FEE_POOL = 300;
+    /// @dev the initial setting of the default protocol fee for dynamic fee pool is 0%
+    uint24 private constant DEFAULT_PROTOCOL_FEE_FOR_DYNAMIC_FEE_POOL = 0;
 
     Vault vault;
     CLPoolManager clPoolManager;
@@ -101,7 +101,7 @@ contract ProtocolFeeControllerTest is Test, BinTestHelper, TokenFixture {
     function testSetDefaultProtocolFeeForDynamicFeePool(uint24 newDefaultProtocolFeeForDynamicFeePool) public {
         ProtocolFeeController controller = new ProtocolFeeController(address(clPoolManager));
 
-        // it should start with 0.03% as default
+        // it should start with 0% as default
         assertEq(controller.defaultProtocolFeeForDynamicFeePool(), DEFAULT_PROTOCOL_FEE_FOR_DYNAMIC_FEE_POOL);
 
         {


### PR DESCRIPTION
## Summary
- Set the initial `defaultProtocolFeeForDynamicFeePool` to `0` so newly created dynamic-fee pools start with no protocol fee.
- Update `ProtocolFeeController` test expectations/comments to match the documented 0% dynamic-fee pool protocol fee.

Fixes #251

## Tests
- `C:\Users\tupm96\.foundry\versions\v1.7.1\forge.exe test --isolate --match-path test/ProtocolFeeController.t.sol -vv`